### PR TITLE
Updates to .xacro and .gazebo file to have the rover visible in Rviz

### DIFF
--- a/models/curiosity_path/urdf/arm.xacro
+++ b/models/curiosity_path/urdf/arm.xacro
@@ -35,7 +35,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -43,7 +43,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -113,7 +113,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_01_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -121,7 +121,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -191,7 +191,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -199,7 +199,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_03_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -270,7 +270,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -278,7 +278,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_04_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -349,7 +349,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -357,7 +357,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/arm_tools_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 

--- a/models/curiosity_path/urdf/chassis.xacro
+++ b/models/curiosity_path/urdf/chassis.xacro
@@ -25,7 +25,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -33,7 +33,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/chassis_full_fixed_glitch_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 

--- a/models/curiosity_path/urdf/curiosity_mars_rover.gazebo
+++ b/models/curiosity_path/urdf/curiosity_mars_rover.gazebo
@@ -50,21 +50,27 @@
       <!-- Wheel Joints Interfaces-->
       <joint name="front_wheel_L_joint">
           <command_interface name="velocity" />
+          <state_interface name="position" />                    
       </joint>
       <joint name="middle_wheel_L_joint">
           <command_interface name="velocity" />
+          <state_interface name="position" />          
       </joint>
       <joint name="back_wheel_L_joint">
           <command_interface name="velocity" />
+          <state_interface name="position" />          
       </joint>
       <joint name="front_wheel_R_joint">
           <command_interface name="velocity" />
+          <state_interface name="position" />                    
       </joint>
       <joint name="middle_wheel_R_joint">
           <command_interface name="velocity" />
+          <state_interface name="position" />                    
       </joint>
       <joint name="back_wheel_R_joint">
           <command_interface name="velocity" />
+          <state_interface name="position" />          
       </joint>
       <!-- Steering Joints Interfaces-->
       <joint name="suspension_steer_F_L_joint">
@@ -112,6 +118,17 @@
           <state_interface name="velocity"/>
           <state_interface name="effort"/>
       </joint>
+
+      <!-- Passive joints - No command interface -->      
+      <joint name="suspension_arm_B2_L_joint">
+          <state_interface name="position"/>
+      </joint>
+
+      <joint name="suspension_arm_B2_R_joint">
+          <state_interface name="position"/>
+      </joint>
+
+      
   </ros2_control>
 
   <gazebo>

--- a/models/curiosity_path/urdf/left_wheel_group.xacro
+++ b/models/curiosity_path/urdf/left_wheel_group.xacro
@@ -9,7 +9,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -17,7 +17,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/left_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -46,7 +46,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -54,7 +54,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -95,7 +95,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -103,7 +103,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -172,7 +172,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -180,7 +180,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B2_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -250,7 +250,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -258,7 +258,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_F_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -398,7 +398,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -406,7 +406,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_B_L_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 

--- a/models/curiosity_path/urdf/right_wheel_group.xacro
+++ b/models/curiosity_path/urdf/right_wheel_group.xacro
@@ -8,7 +8,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -16,7 +16,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/right_axis_jointfix_v2.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -44,7 +44,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -52,7 +52,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -95,7 +95,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -103,7 +103,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -172,7 +172,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -180,7 +180,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_arm_B2_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -251,7 +251,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -259,7 +259,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_F_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -394,7 +394,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -402,7 +402,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/suspension_steer_B_R_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 

--- a/models/curiosity_path/urdf/sensor_mast.xacro
+++ b/models/curiosity_path/urdf/sensor_mast.xacro
@@ -35,7 +35,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -43,7 +43,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/mast_p_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -113,7 +113,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -121,7 +121,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/mast_02_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 
@@ -192,7 +192,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</collision>
 
@@ -200,7 +200,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/mast_cameras.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 

--- a/models/curiosity_path/urdf/wheel.xacro
+++ b/models/curiosity_path/urdf/wheel.xacro
@@ -16,7 +16,7 @@
 			<origin xyz="0 0 0"
 					rpy="0 0 0"/>
 			<geometry>
-				<mesh filename="$(find simulation)/models/curiosity_path/meshes/wheel_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
+				<mesh filename="package://simulation/models/curiosity_path/meshes/wheel_fixed.dae" scale="${scale_XYZ} ${scale_XYZ} ${scale_XYZ}"/>
 			</geometry>
 		</visual>
 


### PR DESCRIPTION
This PR fixes demos #25:  The rover wasn't visible in Rviz. 

**Changes**
1. Changed **$(find simulation)** to **package://simulation** in the xacro files.
2. A few of the joints didn't have a **state interface** in the **ros2_control** tag, hence these joints were not being published in the joint_state topic, which made robot_publisher not publish their transforms.
3. There were a couple of non-actuated joints (**suspension_arm_B2_L_joint** and **suspension_arm_B2_R_joint**)  that were missing in the **ros2_control** tag. We added the joints only with an state interface so their states could be published by the joint_state_broadcaster.

Video (5x) shows the Rover in Rviz, now fully visible. We move the arm and the mast a little bit just to test that the TFs are being updated accordingly.

**How to test**
Start the mars demo as usual. Open an Rviz2 window and set the fixed frame to be /odom. Add a RobotModel display and set the topic name to be /robot_description. Robot should load without errors.


https://github.com/space-ros/simulation/assets/555379/ce0a8abe-88f3-4015-a93e-6f6c438a2cec

