### PR TITLE
Restrict humble packages to humble builds (#41).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,71 +1,80 @@
 cmake_minimum_required(VERSION 3.8)
 project(simulation)
 
+if(DEFINED ENV{ROS_DISTRO})
+    set(ROS_DISTRO $ENV{ROS_DISTRO})
+endif()
+
 # Find required packages
 find_package(ament_cmake REQUIRED)
-find_package(ignition-plugin1 REQUIRED COMPONENTS register)
-find_package(ignition-gazebo6 REQUIRED)
-find_package(ignition-physics5 REQUIRED)
-find_package(ignition-common4 REQUIRED)
-find_package(ignition-rendering6 REQUIRED)
 
-# Set Gazebo plugin and sim versions
-set(IGNITION_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
-set(IGNITION_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
-set(IGNITION_COMMON_VER ${ignition-common4_VERSION_MAJOR})
-set(IGNITION_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
-set(IGNITION_SENSORS_VER ${ignition-sensors6_VERSION_MAJOR})
+if(ROS_DISTRO STREQUAL "humble")
+  # Find required packages
+  find_package(ignition-plugin1 REQUIRED COMPONENTS register)
+  find_package(ignition-gazebo6 REQUIRED)
+  find_package(ignition-physics5 REQUIRED)
+  find_package(ignition-common4 REQUIRED)
+  find_package(ignition-rendering6 REQUIRED)
 
-# Add the plugins directory to the include path
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Plugins)
+  # Set Gazebo plugin and sim versions
+  set(IGNITION_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
+  set(IGNITION_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
+  set(IGNITION_COMMON_VER ${ignition-common4_VERSION_MAJOR})
+  set(IGNITION_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
+  set(IGNITION_SENSORS_VER ${ignition-sensors6_VERSION_MAJOR})
 
-# Add the SolarPanelPlugin library
-add_library(SolarPanelPlugin SHARED
-  plugins/SolarPanelPlugin.cc
-)
+  # Add the plugins directory to the include path
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Plugins)
 
-# Link the SolarPanelPlugin library with required dependencies
-target_link_libraries(SolarPanelPlugin
-  PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
-  PRIVATE ignition-common${IGNITION_COMMON_VER}::ignition-common${IGNITION_COMMON_VER}
-  PRIVATE ignition-rendering${IGNITION_RENDERING_VER}::ignition-rendering${IGNITION_RENDERING_VER}
-  PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
-)
+  # Add the SolarPanelPlugin library
+  add_library(SolarPanelPlugin SHARED
+    plugins/SolarPanelPlugin.cc
+  )
 
-# Add the RadioisotopeThermalGeneratorPlugin library
-add_library(RadioisotopeThermalGeneratorPlugin SHARED
-  plugins/RadioisotopeThermalGeneratorPlugin.cc
-)
+  # Link the SolarPanelPlugin library with required dependencies
+  target_link_libraries(SolarPanelPlugin
+    PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
+    PRIVATE ignition-common${IGNITION_COMMON_VER}::ignition-common${IGNITION_COMMON_VER}
+    PRIVATE ignition-rendering${IGNITION_RENDERING_VER}::ignition-rendering${IGNITION_RENDERING_VER}
+    PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
+  )
 
-# Link the RadioisotopeThermalGeneratorPlugin library with required dependencies
-target_link_libraries(RadioisotopeThermalGeneratorPlugin
-  PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
-  PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
-)
+  # Add the RadioisotopeThermalGeneratorPlugin library
+  add_library(RadioisotopeThermalGeneratorPlugin SHARED
+    plugins/RadioisotopeThermalGeneratorPlugin.cc
+  )
 
-# Add the RechargeableBatteryPlugin library
-add_library(RechargeableBatteryPlugin SHARED
-  plugins/RechargeableBatteryPlugin.cc
-)
+  # Link the RadioisotopeThermalGeneratorPlugin library with required dependencies
+  target_link_libraries(RadioisotopeThermalGeneratorPlugin
+    PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
+    PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
+  )
 
-# Link the RechargeableBatteryPlugin library with required dependencies
-target_link_libraries(RechargeableBatteryPlugin
-  PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
-  PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
-)
+  # Add the RechargeableBatteryPlugin library
+  add_library(RechargeableBatteryPlugin SHARED
+    plugins/RechargeableBatteryPlugin.cc
+  )
 
-# add the SensorPowerSystemPlugin library
-add_library(SensorPowerSystemPlugin SHARED
-  plugins/SensorPowerSystemPlugin.cc
-)
+  # Link the RechargeableBatteryPlugin library with required dependencies
+  target_link_libraries(RechargeableBatteryPlugin
+    PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
+    PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
+  )
 
-# Link the SensorPowerSystemPlugin library with required dependencies
-target_link_libraries(SensorPowerSystemPlugin
-  PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
-  PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
-  PRIVATE ignition-gazebo${IGNITION_SIM_VER}::ignition-gazebo${IGNITION_SIM_VER}
-  PRIVATE ignition-sensors${IGNITION_SENSORS_VER}::ignition-sensors${IGNITION_SENSORS_VER}
-)
+  # add the SensorPowerSystemPlugin library
+  add_library(SensorPowerSystemPlugin SHARED
+    plugins/SensorPowerSystemPlugin.cc
+  )
+
+  # Link the SensorPowerSystemPlugin library with required dependencies
+  target_link_libraries(SensorPowerSystemPlugin
+    PRIVATE ignition-plugin${IGNITION_PLUGIN_VER}::ignition-plugin${IGNITION_PLUGIN_VER}
+    PRIVATE ignition-gazebo${IGNITION_SIM_VER}::core
+    PRIVATE ignition-gazebo${IGNITION_SIM_VER}::ignition-gazebo${IGNITION_SIM_VER}
+    PRIVATE ignition-sensors${IGNITION_SENSORS_VER}::ignition-sensors${IGNITION_SENSORS_VER}
+  )
+
+endif()
 
 # Create the models directory
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/models/curiosity_path)
@@ -77,12 +86,14 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
-# Install the plugin library
-install(TARGETS SolarPanelPlugin RadioisotopeThermalGeneratorPlugin RechargeableBatteryPlugin SensorPowerSystemPlugin
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
+if(ROS_DISTRO STREQUAL "humble")
+  # Install the plugin library
+  install(TARGETS SolarPanelPlugin RadioisotopeThermalGeneratorPlugin RechargeableBatteryPlugin SensorPowerSystemPlugin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+endif()
 
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
 

--- a/package.xml
+++ b/package.xml
@@ -7,19 +7,20 @@
   <maintainer email="dharini@openrobotics.org">Dharini Dutia</maintainer>
   <license>Apache-2.0</license>
 
+  <buildtool_depend>ros_environment</buildtool_depend>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>ign-cmake2</depend>
-  <depend>ign-plugin1</depend>
-  <depend>ign-common4</depend>
-  <depend>ign-gazebo6</depend>
-  <depend>ign-rendering6</depend>
-  <depend>ign-sensors6</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">ign-cmake2</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">ign-plugin1</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">ign-common4</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">ign-gazebo6</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">ign-rendering6</depend>
+  <depend condition="$ROS_DISTRO == 'humble'">ign-sensors6</depend>
 
   <exec_depend>xacro</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>
-    <gazebo_ros gazebo_plugin_path="${prefix}/lib"/>
+    <gazebo_ros condition="$ROS_DISTRO == 'humble'" gazebo_plugin_path="${prefix}/lib"/>
   </export>
 </package>


### PR DESCRIPTION
A recent update caused some packages to break due to them not being able to build the simulation repo when being installed on jazzy. This is affecting the demos repo, where now some demos no longer build.  To keep this working until we can update all demos for jazzy, we want to protect the parts of the CMakeLists.txt that are specific to a ROS distro, so that they are ignored in other cases.

This PR makes the parts of the `CMakeLists.txt` and `package.xml` that are only for `humble` conditional, so that they are only built on that ROS distribution.