### PR TITLE
Drop the leading slashes from the rover odometry frame names (fixes #45)

### DIFF
--- a/models/curiosity_path/urdf/curiosity_mars_rover.gazebo
+++ b/models/curiosity_path/urdf/curiosity_mars_rover.gazebo
@@ -139,8 +139,8 @@
       </plugin>
 
       <plugin filename="ignition-gazebo-odometry-publisher-system" name="ignition::gazebo::systems::OdometryPublisher">
-          <odom_frame>/odom</odom_frame>
-          <robot_base_frame>/base_footprint</robot_base_frame>
+          <odom_frame>odom</odom_frame>
+          <robot_base_frame>base_footprint</robot_base_frame>
           <odom_publish_frequency>10</odom_publish_frequency>
       </plugin>
 

--- a/models/lunar_pole_exploration_rover/urdf/lunar_pole_exploration_rover.gazebo
+++ b/models/lunar_pole_exploration_rover/urdf/lunar_pole_exploration_rover.gazebo
@@ -81,8 +81,8 @@
         </plugin>
 
         <plugin filename="ignition-gazebo-odometry-publisher-system" name="ignition::gazebo::systems::OdometryPublisher">
-            <odom_frame>/odom</odom_frame>
-            <robot_base_frame>/base_footprint</robot_base_frame>
+            <odom_frame>odom</odom_frame>
+            <robot_base_frame>base_footprint</robot_base_frame>
             <odom_publish_frequency>10</odom_publish_frequency>
         </plugin>
 


### PR DESCRIPTION
Fixes #45.

`/odom` → `odom` and `/base_footprint` → `base_footprint` in the odometry publisher configuration of the lunar pole and curiosity models. ROS 2 tf2 frame ids must not start with a slash; the demos' `odom_tf_publisher` nodes copy the names from the odometry message into `/tf`, so the transform went out as `/odom` → `/base_footprint` and only resolved because tf2 strips the slashes on the way in.

Nothing consumes the slashed names on purpose: the demos' `odom_tf_publisher` nodes copy whatever the message carries, and the demo READMEs refer to `odom` and `base_footprint`. The Jazzy `curiosity_rover` and `nav2_demo` demos ship their own copy of the curiosity model in the demos repository, so they are unaffected either way.

Verified on the lunar pole rover (Harmonic, Jazzy demo, GUI run): the odometry message and `/tf` carry `odom` → `base_footprint`, and `ros2 run tf2_ros tf2_echo odom base_link` resolves without the earlier warning.
